### PR TITLE
added dummy partition time constraint in distinct dimensions query

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/sql/SqlUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/sql/SqlUtils.java
@@ -294,8 +294,19 @@ public class SqlUtils {
   }
 
   static String getDimensionFiltersSQL(String dimension, String tableName, String sourceName) {
-    // FIXME for databases having time partition optimization, get different dim values in relevant timeframe
-    return "SELECT DISTINCT(" + dimension + ") FROM " + tableName;
+    // FIXME for databases having time partition optimization, get different dim values in a RELEVANT timeframe
+    DateTime currentTime = DateTime.now();
+    DateTime startTime = currentTime.minusYears(3);
+    DateTime endTime = currentTime.plusYears(1);
+    String datePartitionClause = getDatePartitionClause(startTime, endTime, sourceName);
+
+    String distinctDimensionsQuery = "SELECT DISTINCT(" + dimension + ") FROM " + tableName;
+
+    if (datePartitionClause != null) {
+      return distinctDimensionsQuery + " WHERE " + datePartitionClause;
+    } else {
+      return distinctDimensionsQuery;
+    }
   }
 
   private static String getSelectionClause(MetricConfigDTO metricConfig, MetricFunction metricFunction, List<String> groupByKeys, TimeGranularity granularity, TimeSpec dateTimeSpec) {

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/datasource/sql/TestSqlUtils.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/datasource/sql/TestSqlUtils.java
@@ -138,7 +138,7 @@ public class TestSqlUtils {
   }
 
   @Test
-  public void testGetMaxDataTimeSQL() {
+  public void testGetMaxDataTimeSQLForBigQuery() {
     String timeColumn = "date";
     String tableName = "table_name";
 
@@ -146,6 +146,19 @@ public class TestSqlUtils {
     String actual = SqlUtils.getMaxDataTimeSQL(timeColumn, tableName, "BigQuery");
 
     String expected = "SELECT MAX(" + timeColumn + ") FROM " + tableName + " WHERE " + "_PARTITIONTIME >= '2020-11-30 00:00:00' AND _PARTITIONTIME <= '2021-02-10 00:00:00'";
+    Assert.assertEquals(actual, expected);
+
+  }
+
+  @Test
+  public void testGetDimensionFiltersSQLForBigQuery() {
+    String dimension = "myDimension";
+    String tableName = "table_name";
+
+    DateTimeUtils.setCurrentMillisFixed(1612137600000L); // 2021-02-01 00:00:00
+    String actual = SqlUtils.getDimensionFiltersSQL(dimension, tableName, "BigQuery");
+
+    String expected = "SELECT DISTINCT(" + dimension + ") FROM " + tableName + " WHERE " + "_PARTITIONTIME >= '2018-01-31 00:00:00' AND _PARTITIONTIME <= '2022-02-03 00:00:00'";
     Assert.assertEquals(actual, expected);
 
   }


### PR DESCRIPTION
added dummy partition time constraint in distinct dimensions query

to be compatible with our dataset that enforce time partition usage 