### PR TITLE
smaller timeframe for distinct values of dimensions

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/sql/SqlUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/sql/SqlUtils.java
@@ -296,8 +296,8 @@ public class SqlUtils {
   static String getDimensionFiltersSQL(String dimension, String tableName, String sourceName) {
     // FIXME for databases having time partition optimization, get different dim values in a RELEVANT timeframe
     DateTime currentTime = DateTime.now();
-    DateTime startTime = currentTime.minusYears(3);
-    DateTime endTime = currentTime.plusYears(1);
+    DateTime startTime = currentTime.minusMonths(2);
+    DateTime endTime = currentTime.plusMonths(1);
     String datePartitionClause = getDatePartitionClause(startTime, endTime, sourceName);
 
     String distinctDimensionsQuery = "SELECT DISTINCT(" + dimension + ") FROM " + tableName;

--- a/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/datasource/sql/TestSqlUtils.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/org/apache/pinot/thirdeye/datasource/sql/TestSqlUtils.java
@@ -158,7 +158,7 @@ public class TestSqlUtils {
     DateTimeUtils.setCurrentMillisFixed(1612137600000L); // 2021-02-01 00:00:00
     String actual = SqlUtils.getDimensionFiltersSQL(dimension, tableName, "BigQuery");
 
-    String expected = "SELECT DISTINCT(" + dimension + ") FROM " + tableName + " WHERE " + "_PARTITIONTIME >= '2018-01-31 00:00:00' AND _PARTITIONTIME <= '2022-02-03 00:00:00'";
+    String expected = "SELECT DISTINCT(" + dimension + ") FROM " + tableName + " WHERE " + "_PARTITIONTIME >= '2020-11-30 00:00:00' AND _PARTITIONTIME <= '2021-03-03 00:00:00'";
     Assert.assertEquals(actual, expected);
 
   }


### PR DESCRIPTION
dimensions cache was too big + query too long and not relevant

hotfix: start - endtime could be better, depend on analysis frame