### PR TITLE
add mariadb compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -687,6 +687,21 @@
                 </dependencies>
             </dependencyManagement>
         </profile>
+        <profile>
+            <id>mariadb</id>
+            <properties>
+                <mariadb.connector.version>2.7.4</mariadb.connector.version>
+            </properties>
+            <dependencyManagement>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.mariadb.jdbc</groupId>
+                        <artifactId>mariadb-java-client</artifactId>
+                        <version>${mariadb.connector.version}</version>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
+        </profile>
     </profiles>
 
     <reporting>

--- a/quickstart/Dockerfile
+++ b/quickstart/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8 as thirdeye_build_env
 
-ARG PINOT_BRANCH=mysql-quickstart
+ARG PINOT_BRANCH=master
 ARG PINOT_GIT_URL="https://github.com/cyrilou242/incubator-pinot.git"
 RUN echo "Trying to build Thirdeye from [ ${PINOT_GIT_URL} ] on branch [ ${PINOT_BRANCH} ]"
 

--- a/quickstart/docker-compose.yml
+++ b/quickstart/docker-compose.yml
@@ -23,3 +23,9 @@ services:
       - "3307:3306"
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+  mariadb:
+    image: mariadb:10.7
+    ports:
+      - "3307:3306"
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "true"

--- a/thirdeye-pinot/pom.xml
+++ b/thirdeye-pinot/pom.xml
@@ -372,6 +372,15 @@
           </dependency>
         </dependencies>
     </profile>
+    <profile>
+      <id>mariadb</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.mariadb.jdbc</groupId>
+          <artifactId>mariadb-java-client</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 
   <build>


### PR DESCRIPTION
To build with maridadb compatibility: 
`./install.sh mariadb`

Configuration example: 
```
dataSourceConfigs:
  - className: org.apache.pinot.thirdeye.datasource.sql.SqlThirdEyeDataSource
    properties:
      MySQL:
        - db:
            ## notice the &useSSL=false
            dataset: jdbc:mariadb://localhost:3307/testdata?autoReconnect=true&useSSL=false
          user: root
          password: ""
          driver: org.mariadb.jdbc.Driver
```